### PR TITLE
Add new regex pattern to log config patterns

### DIFF
--- a/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/standalone/log-config/patterns.xml
+++ b/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/standalone/log-config/patterns.xml
@@ -49,13 +49,8 @@
     </pattern>
 
     <pattern key="pattern6">
-        <detectPattern>(.)*User,(.)*${username}@${tenantDomain}(.)*is(\s)not(\s)exist(\s)in(.)*${userstoreDomain}(.)*</detectPattern>
+        <detectPattern>(.)*(CarbonAuthenticationUtil)(.)*${username}@${tenantDomain}(.)*</detectPattern>
         <replacePattern>${username}</replacePattern>
-    </pattern>
-
-    <pattern key="pattern6">
-        <detectPattern>(.)*${username}(.)*</detectPattern>
-        <replacePattern></replacePattern>
     </pattern>
 
 </patterns>


### PR DESCRIPTION
## Purpose
> To identify logs which get printed from CarbonAuthenticationUtil

## Goals
> This pattern will help to identify the following log from logs file.
`INFO {org.wso2.carbon.core.services.util.CarbonAuthenticationUtil} -  'username@tenantDomain [-1234]' logged in at [2018-02-19 14:14:02,997+0530]`

## Approach
> Removed a faulty pattern and added a new regex pattern to identify logs which get printed from CarbonAuthenticationUtil.