### PR TITLE
Add file-exception to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.iml
 lib/
 target/
+.DS_Store


### PR DESCRIPTION
## Purpose
> To avoid getting .DS_Store (Apple directory meta-data) attached to commits.

## Approach
> Added a file exception to .gitignore to ignore .DS_Store file.