### PR TITLE
Add product specific configs to the tool

### DIFF
--- a/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/products/ei/conf/config-ei.json
+++ b/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/products/ei/conf/config-ei.json
@@ -1,0 +1,19 @@
+{
+  "processors" : [
+    "rdbms"
+  ],
+  "directories": [
+    {
+      "dir": "sql",
+      "type": "rdbms",
+      "processor" : "rdbms"
+    }
+  ],
+  "extensions": [
+    {
+      "dir": "datasources",
+      "type": "datasource",
+      "processor" : "rdbms"
+    }
+  ]
+}

--- a/components/org.wso2.carbon.privacy.forgetme.tool/src/main/assembly/bin.xml
+++ b/components/org.wso2.carbon.privacy.forgetme.tool/src/main/assembly/bin.xml
@@ -69,6 +69,10 @@
             <directory>${basedir}/../org.wso2.carbon.privacy.forgetme.conf/target/conf/products/ei/log-config</directory>
             <outputDirectory>identity-anonymization-tool-${pom.version}/conf/log-config</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>${basedir}/../org.wso2.carbon.privacy.forgetme.conf/target/conf/products/ei/conf/</directory>
+            <outputDirectory>identity-anonymization-tool-${pom.version}/conf/product-config</outputDirectory>
+        </fileSet>
 
         <!--IS related configs -->
         <fileSet>
@@ -85,6 +89,10 @@
             </directory>
             <outputDirectory>identity-anonymization-tool-${pom.version}/conf/log-config</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>${basedir}/../org.wso2.carbon.privacy.forgetme.conf/target/conf/products/identity/conf/</directory>
+            <outputDirectory>identity-anonymization-tool-${pom.version}/conf/product-config</outputDirectory>
+        </fileSet>
 
         <!--APIM related configs -->
         <fileSet>
@@ -99,6 +107,10 @@
             <directory>${basedir}/../org.wso2.carbon.privacy.forgetme.conf/target/conf/products/apim/log-config</directory>
             <outputDirectory>identity-anonymization-tool-${pom.version}/conf/log-config</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>${basedir}/../org.wso2.carbon.privacy.forgetme.conf/target/conf/products/apim/conf/</directory>
+            <outputDirectory>identity-anonymization-tool-${pom.version}/conf/product-config</outputDirectory>
+        </fileSet>
 
         <!--IOT related configs -->
         <fileSet>
@@ -112,6 +124,10 @@
         <fileSet>
             <directory>${basedir}/../org.wso2.carbon.privacy.forgetme.conf/target/conf/products/iot/log-config</directory>
             <outputDirectory>identity-anonymization-tool-${pom.version}/conf/log-config</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${basedir}/../org.wso2.carbon.privacy.forgetme.conf/target/conf/products/iot/conf/</directory>
+            <outputDirectory>identity-anonymization-tool-${pom.version}/conf/product-config</outputDirectory>
         </fileSet>
     </fileSets>
 


### PR DESCRIPTION
## Purpose
> The purpose of this change is to make all products related config available in OOB.

## Goals
> Make configurations available from a single place.

## Approach
> Product related configs were copied to a "product-config" directory inside the tool.