### PR TITLE
Add log file processor to the EI config

### DIFF
--- a/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/products/ei/conf/config-ei.json
+++ b/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/products/ei/conf/config-ei.json
@@ -1,8 +1,29 @@
 {
   "processors" : [
-    "rdbms"
+    "rdbms", "log-file"
   ],
   "directories": [
+    {
+      "dir": "log-config",
+      "type": "log-file",
+      "processor" : "log-file",
+      "log-file-path" : "logs",
+      "log-file-name-regex" : "wso2carbon.log"
+    },
+    {
+      "dir": "log-config",
+      "type": "log-file",
+      "processor" : "log-file",
+      "log-file-path" : "logs",
+      "log-file-name-regex" : "audit.log"
+    },
+    {
+      "dir": "log-config",
+      "type": "log-file",
+      "processor" : "log-file",
+      "log-file-path" : "logs",
+      "log-file-name-regex" : "warn.log"
+    },
     {
       "dir": "sql",
       "type": "rdbms",


### PR DESCRIPTION
## Purpose
> To cleanse usernames in the log files

## Goals
> To compliant with GDPR forget me right

## Approach
> Added log-file processor to the EI configuration in order to process defined set of log files