### PR TITLE
Fix the path name issue in Windows

### DIFF
--- a/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/ForgetMeExecutionEngine.java
+++ b/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/ForgetMeExecutionEngine.java
@@ -221,9 +221,7 @@ public class ForgetMeExecutionEngine {
         }
 
         private String getReportFileName() {
-
-            SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
-            return "Report-" + name + "-" + simpleDateFormat.format(new Date()) + ".txt";
+            return "Report-" + name + "-" + System.currentTimeMillis() + ".txt";
         }
     }
 }


### PR DESCRIPTION
Windows path names cannot have ":" in it. So this will change the date time in path name to a timestamp.
