### PR TITLE
Modify ei-config.json

### DIFF
--- a/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/products/ei/conf/config-ei.json
+++ b/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/products/ei/conf/config-ei.json
@@ -1,28 +1,14 @@
 {
   "processors" : [
-    "rdbms", "log-file"
+    "log-file"
   ],
   "directories": [
     {
       "dir": "log-config",
       "type": "log-file",
       "processor" : "log-file",
-      "log-file-path" : "logs",
-      "log-file-name-regex" : "wso2carbon.log"
-    },
-    {
-      "dir": "log-config",
-      "type": "log-file",
-      "processor" : "log-file",
-      "log-file-path" : "logs",
-      "log-file-name-regex" : "audit.log"
-    },
-    {
-      "dir": "log-config",
-      "type": "log-file",
-      "processor" : "log-file",
-      "log-file-path" : "logs",
-      "log-file-name-regex" : "warn.log"
+      "log-file-path" : "repository/logs",
+      "log-file-name-regex" : "(audit.log|warn.log|wso2carbon.log|Sample-proxyservice.log)(.)*"
     },
     {
       "dir": "sql",


### PR DESCRIPTION
## Purpose
> The default configuration should support to execute the tool to anonymize the user PII information. According to the current config.json file it is configured to execute the sql file that contains the PII identification anonymization process for business-process server as well.

## Goals
> To resolve wso2/product-ei#1910

## Approach
> Modified to run log anonymization as the default for EI. Also updated the log file name regex pattern.