### PR TITLE
Fix issue in analytics stream file

### DIFF
--- a/components/org.wso2.carbon.privacy.forgetme.analytics.streams/src/main/java/org/wso2/carbon/privacy/forgetme/analytics/streams/instructions/AnalyticsStreamsInstruction.java
+++ b/components/org.wso2.carbon.privacy.forgetme.analytics.streams/src/main/java/org/wso2/carbon/privacy/forgetme/analytics/streams/instructions/AnalyticsStreamsInstruction.java
@@ -126,6 +126,11 @@ public class AnalyticsStreamsInstruction implements ForgetMeInstruction {
     private void filterRecords(AnalyticsDataService analyticsDataService, UserIdentifier userIdentifier,
                                Streams.Stream stream) {
 
+        // We cannot proceed if the stream is null. This can be happen due to empty stream definitions in the file.
+        if (stream == null) {
+            return;
+        }
+
         try {
             AnalyticsDataResponse analyticsDataResponse = analyticsDataService.get(userIdentifier.getTenantId(),
                     getTableName(stream.getStreamName()), 1, null, Long.MIN_VALUE, Long.MAX_VALUE, 0,

--- a/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/products/identity/analytics/streams/is-streams.json
+++ b/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/products/identity/analytics/streams/is-streams.json
@@ -14,6 +14,6 @@
       "streamName": "org.wso2.is.analytics.stream.LoginSuccessAfterMultipleFailures",
       "attributes": ["username"],
       "id": "username"
-    },
+    }
   ]
 }


### PR DESCRIPTION
## Purpose
> Fix a issue in analytics stream where extra ',' is presented at the end of the .json file. 

## Goals
> N/A

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A


## Documentation
> N/A

## Training
> N/A


## Certification
> N/A

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.