### PR TITLE
Modify das-patterns.xml

### DIFF
--- a/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/products/das/log-config/das-patterns.xml
+++ b/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/products/das/log-config/das-patterns.xml
@@ -30,6 +30,10 @@
         <detectPattern>(.)*login as ${username}</detectPattern>
         <replacePattern>${username}</replacePattern>
     </pattern>
+    <pattern key="product-das-3">
+        <detectPattern>(.)*(${username}@${tenantDomain}(\s)*(\[)${tenantId}(\])|)(.)*(Failed Administrator login attempt ')${username}(\[)${tenantId}(\]' at)</detectPattern>
+        <replacePattern>(${username}(\[)${tenantId}(\])(.)*|${username}@${tenantDomain})</replacePattern>
+    </pattern>
     
     <pattern key="carbon-dashboards-1">
         <detectPattern>(.)*a user logged out from the portal username: ${username}, domain:${userstoreDomain}</detectPattern>


### PR DESCRIPTION
## Purpose
> The default log configuration should support to anonymize the user PII information. According to the current das-patterns.xml file, PII information printed on the logs when a login attept failure is not anonymized.

## Goals
> To resolve [wso2/product-das#320](https://github.com/wso2/product-das/issues/320)

## Approach
> Add pattern to anonymize log for a login attempt failure.