### PR TITLE
Add SHA256 hashing functionality for generating the pseudonym

### DIFF
--- a/components/org.wso2.carbon.privacy.forgetme.tool/pom.xml
+++ b/components/org.wso2.carbon.privacy.forgetme.tool/pom.xml
@@ -69,6 +69,10 @@
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/components/org.wso2.carbon.privacy.forgetme.tool/src/main/resources/help.md
+++ b/components/org.wso2.carbon.privacy.forgetme.tool/src/main/resources/help.md
@@ -37,6 +37,10 @@ User Store Domain (optional)|Default = “PRIMARY”
 example
 > -D Finance-Domain
 
+###### Option sha256
+To enable SHA256 hashing for anonymizing the given ID attribute (optional)
+> -sha256
+
 ###### Option pu
 The pseudonym which the user name needs to be
 replaced with. (optional)  Default = A random UUID

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
   ~ under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -200,6 +201,11 @@
                 <version>${org.testng.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -225,6 +231,7 @@
         <antrun.plugin.version>1.7</antrun.plugin.version>
         <appasembler.plugin.version>2.0.0</appasembler.plugin.version>
         <jacoco.version>0.7.9</jacoco.version>
+        <commons-codec.version>1.4</commons-codec.version>
 
         <org.junit.version>3.8.1</org.junit.version>
         <org.testng.version>6.11</org.testng.version>


### PR DESCRIPTION
## Purpose
> In anonymizing the PII, there may be times that the anonymized user still needs to be uniquely identified across others users ( both anonymize and non-anonymize). In a scenario like above using a randomly generated UUID value for replacing the PII is not valid. This PR introduces the functionality to hash the required PII, so that the PII left anonymized but can be uniquely identified across other records.  Resolves #78 

## Goals
> Providing the functionality for hashing PII in `SHA256` digesting algorithm

## Approach
> If `sha256` option is provided the given PII will be anonymized by using `SHA256` digesting algorithm.

## User stories
> The user of the tool needs to provide `sha256` option in order to use `SHA256` hashing for anonymizing the PII

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > No
 - Integration tests
   > No
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> `./forgetme.sh -U kasunsi@wso2.com -d /home/ubuntu/identity-anonymization-tool-1.1.20-SNAPSHOT/conf/ -carbon /home/ubuntu/wso2das-3.1.0/ -sha256`
## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> `Ubuntu 16.04` with `JDK 1.8.0_131` and `maven 3.0.5`
 
## Learning
> N/A