### PR TITLE
Moving buffer initialization into try () block to use java automatic resource close

### DIFF
--- a/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/ForgetMeTool.java
+++ b/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/ForgetMeTool.java
@@ -148,11 +148,10 @@ public class ForgetMeTool {
      */
     private static void emitHelp(PrintStream out) {
 
-        InputStream inputStream = ForgetMeTool.class.getClassLoader().getResourceAsStream("help.md");
-        ReadableByteChannel readableByteChannel = Channels.newChannel(inputStream);
-        WritableByteChannel writableByteChannel = Channels.newChannel(out);
         ByteBuffer buffer = ByteBuffer.allocateDirect(512);
-        try {
+        try ( InputStream inputStream = ForgetMeTool.class.getClassLoader().getResourceAsStream("help.md");
+              ReadableByteChannel readableByteChannel = Channels.newChannel(inputStream);
+              WritableByteChannel writableByteChannel = Channels.newChannel(out) ) {
             while (readableByteChannel.read(buffer) != -1) {
                 buffer.flip();
                 while (buffer.hasRemaining()) {


### PR DESCRIPTION
## Purpose
The resources are not released after use.

## Goals
Proper releasing of resources after use

## Approach
Use Java 7 initializing resource in try () to automatically close resource

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Java 1.8.0_137

## Learning
N/A
