### PR TITLE
Fix anomyzation of 'performedBy' placeholder in audit log-config apim pattern 4

### DIFF
--- a/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/products/apim/log-config/apim-patterns.xml
+++ b/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/products/apim/log-config/apim-patterns.xml
@@ -40,7 +40,7 @@
 
       <pattern key="pattern4">
           <detectPattern>(.)*(\{"performedBy":")${username}(")(.)*(|(\\"provider\\":\\")${username}(\\")|(\\"provider\\":\\")${username}(-AT-)${tenantDomain}(\\"))</detectPattern>
-          <replacePattern>(("performedBy":")${username}(")|(\\"provider\\":\\")${username}(\\")|(\\"provider\\":\\")${username}(-AT-)${tenantDomain}(\\"))</replacePattern>
+          <replacePattern>(${username}(")|(\\"provider\\":\\")${username}(\\")|(\\"provider\\":\\")${username}(-AT-)${tenantDomain}(\\"))</replacePattern>
       </pattern>
 
       <pattern key="pattern5">


### PR DESCRIPTION
## Purpose
Eventhough only the user's PII information(username in this case) should be anonymized, the forget me tool also replace the "performedBy" part in audit.log file. This is not correct since if the log contents are processed for any other purpose by the user, it would be breaked due to this issue. Original placeholders should not be changed by anonymization.

Fix for https://github.com/wso2/product-apim/issues/2909

## Approach
> Updated the replace pattern in pattern 4 of apim-patterns.xml as " (${username}(")|(\\"provider\\":\\")${username}(\\")|(\\"provider\\":\\")${username}(-AT-)${tenantDomain}(\\")) ".
