### PR TITLE
Support renaming username from forget-me tool execution

### DIFF
--- a/components/org.wso2.carbon.privacy.forgetme.api/src/main/java/org/wso2/carbon/privacy/forgetme/api/report/CloseableReportAppender.java
+++ b/components/org.wso2.carbon.privacy.forgetme.api/src/main/java/org/wso2/carbon/privacy/forgetme/api/report/CloseableReportAppender.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.privacy.forgetme.api.report;
+
+import org.wso2.carbon.privacy.forgetme.api.runtime.InstructionExecutionException;
+
+/**
+ * Closeable report generator to be passed to each instruction to generate a report.
+ *
+ */
+public interface CloseableReportAppender extends ReportAppender, AutoCloseable {
+
+    /**
+     * Opens the report generator resources for report generation.
+     *
+     * @throws InstructionExecutionException
+     */
+    void open() throws InstructionExecutionException;
+
+    /**
+     * Closes report generator resources.
+     *
+     * @throws InstructionExecutionException
+     */
+    void close() throws InstructionExecutionException;
+
+}

--- a/components/org.wso2.carbon.privacy.forgetme.api/src/main/java/org/wso2/carbon/privacy/forgetme/api/report/CloseableReportAppenderBuilder.java
+++ b/components/org.wso2.carbon.privacy.forgetme.api/src/main/java/org/wso2/carbon/privacy/forgetme/api/report/CloseableReportAppenderBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.privacy.forgetme.api.report;
+
+import org.wso2.carbon.privacy.forgetme.api.runtime.ModuleException;
+import org.wso2.carbon.privacy.forgetme.api.user.UserIdentifier;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Closeable report appender builder which builds the appender for the given parameters.
+ */
+public interface CloseableReportAppenderBuilder {
+
+    /**
+     * Returns the report appender type.
+     *
+     * @return report appender type
+     */
+    String getType();
+
+    /**
+     * Returns a closeable report appender instantiated for given properties.
+     *
+     * @param processor processor name
+     * @param reportDirectoryPath report path
+     * @param properties any property the builder may use to build the appender
+     * @param userIdentifier user identifier
+     * @return an instance of a CloseableReportAppender
+     * @throws ModuleException
+     */
+    CloseableReportAppender build(String processor, Path reportDirectoryPath, Map<String, String> properties, UserIdentifier
+            userIdentifier) throws ModuleException;
+}

--- a/components/org.wso2.carbon.privacy.forgetme.rest/src/main/java/org/wso2/carbon/privacy/forgetme/rest/UserService.java
+++ b/components/org.wso2.carbon.privacy.forgetme.rest/src/main/java/org/wso2/carbon/privacy/forgetme/rest/UserService.java
@@ -29,6 +29,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
 /**
+ * @deprecated This service is made redundant and the service API and implementation is moved to identity-governance.
+ * Replaced with service API: /t/{tenant-domain}/api/identity/user/v1.0/update-username
+ *
  * API implementation for user store operations.
  */
 @Path("/user")
@@ -44,13 +47,7 @@ public class UserService {
                            @PathParam("username") String username,
                            User user) {
 
-        try {
-
-            new ForgetMeToolExecutor().execute(tenantId, tenantDomain, userStoreDomain, username, user);
-
-        } catch (Exception e) {
-            log.error("An error occurred while renaming the user.", e);
-        }
+       log.warn("Invoked deprecated /forgetme/v1.0/user API.");
     }
 
 }

--- a/components/org.wso2.carbon.privacy.forgetme.sql/src/main/java/org/wso2/carbon/privacy/forgetme/sql/instructions/RdbmsForgetMeInstruction.java
+++ b/components/org.wso2.carbon.privacy.forgetme.sql/src/main/java/org/wso2/carbon/privacy/forgetme/sql/instructions/RdbmsForgetMeInstruction.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.privacy.forgetme.api.user.UserIdentifier;
 import org.wso2.carbon.privacy.forgetme.sql.config.DataSourceConfig;
 import org.wso2.carbon.privacy.forgetme.sql.exception.SQLModuleException;
 import org.wso2.carbon.privacy.forgetme.sql.module.AMApplicationRegistrationSQLExecutionModule;
+import org.wso2.carbon.privacy.forgetme.sql.module.DomainAppendedPseudonymSQLExecutionModule;
 import org.wso2.carbon.privacy.forgetme.sql.module.DomainAppendedSQLExecutionModule;
 import org.wso2.carbon.privacy.forgetme.sql.module.DomainSeparatedSQLExecutionModule;
 import org.wso2.carbon.privacy.forgetme.sql.module.IDNOauthConsumerAppsSQLExecutionModule;
@@ -126,6 +127,11 @@ public class RdbmsForgetMeInstruction implements ForgetMeInstruction {
                         break;
                     case SELECT_PROCEEDED_UPDATE:
                         break;
+                    case DOMAIN_APPENDED_PSEUDONYM:
+                        sqlExecutionModule = new DomainAppendedPseudonymSQLExecutionModule(dataSourceConfig);
+                        sqlExecutionModule.execute(userSQLQuery);
+                        break;
+
                     default:
                         throw new SQLModuleException("Cannot find a suitable execution module.");
                 }

--- a/components/org.wso2.carbon.privacy.forgetme.sql/src/main/java/org/wso2/carbon/privacy/forgetme/sql/module/DomainAppendedPseudonymSQLExecutionModule.java
+++ b/components/org.wso2.carbon.privacy.forgetme.sql/src/main/java/org/wso2/carbon/privacy/forgetme/sql/module/DomainAppendedPseudonymSQLExecutionModule.java
@@ -95,8 +95,7 @@ public class DomainAppendedPseudonymSQLExecutionModule implements Module<UserSQL
             namedPreparedStatement.getPreparedStatement().execute();
 
             if (log.isDebugEnabled()) {
-                log.debug("Executed the sql query: {} for {}.", userSQLQuery.getSqlQuery().toString(), userSQLQuery
-                        .getUserIdentifier());
+                log.debug("Executed the sql query: {}", userSQLQuery.getSqlQuery().toString());
             }
         } catch (SQLException e) {
             throw new SQLModuleException(e);

--- a/components/org.wso2.carbon.privacy.forgetme.sql/src/main/java/org/wso2/carbon/privacy/forgetme/sql/module/DomainAppendedPseudonymSQLExecutionModule.java
+++ b/components/org.wso2.carbon.privacy.forgetme.sql/src/main/java/org/wso2/carbon/privacy/forgetme/sql/module/DomainAppendedPseudonymSQLExecutionModule.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.privacy.forgetme.sql.module;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.carbon.privacy.forgetme.api.runtime.ModuleException;
+import org.wso2.carbon.privacy.forgetme.sql.config.DataSourceConfig;
+import org.wso2.carbon.privacy.forgetme.sql.exception.SQLModuleException;
+import org.wso2.carbon.privacy.forgetme.sql.sql.UserSQLQuery;
+import org.wso2.carbon.privacy.forgetme.sql.util.NamedPreparedStatement;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+
+/**
+ * SQL execution module to execute queries that needs to have the domain name appended to the give pseudonym.
+ */
+public class DomainAppendedPseudonymSQLExecutionModule implements Module<UserSQLQuery> {
+
+    private static final Logger log = LoggerFactory.getLogger(DomainAppendedPseudonymSQLExecutionModule.class);
+
+    private static final String USERNAME = "username";
+    private static final String TENANT_ID = "tenant_id";
+    private static final String PSEUDONYM = "pseudonym";
+    private static final String PRIMARY_DOMAIN = "PRIMARY";
+    private static final String DOMAIN_SEPARATOR = "/";
+
+    private DataSource dataSource;
+
+    public DomainAppendedPseudonymSQLExecutionModule(DataSourceConfig dataSourceConfig) throws SQLModuleException {
+
+        try {
+            dataSource = dataSourceConfig.getDatasource();
+            if (log.isDebugEnabled()) {
+                log.debug("Data source initialized with name: {}.", dataSource.getClass());
+            }
+        } catch (SQLModuleException e) {
+            throw new SQLModuleException("Error occurred while initializing the data source.", e);
+        }
+    }
+
+    @Override
+    public void execute(UserSQLQuery userSQLQuery) throws ModuleException {
+
+        if (dataSource == null) {
+            log.warn("No data source configured for name: " + userSQLQuery.getSqlQuery().getBaseDirectory());
+            return;
+        }
+
+        String username = userSQLQuery.getUserIdentifier().getUsername();
+        String pseudonym = userSQLQuery.getUserIdentifier().getPseudonym();
+
+        // If this user is in a secondary domain, append the domain name to username and pseudonym.
+        if (!StringUtils.equals(userSQLQuery.getUserIdentifier().getUserStoreDomain(), PRIMARY_DOMAIN)) {
+            username = userSQLQuery.getUserIdentifier().getUserStoreDomain() + DOMAIN_SEPARATOR + username;
+            pseudonym = userSQLQuery.getUserIdentifier().getUserStoreDomain() + DOMAIN_SEPARATOR + pseudonym;
+        }
+
+        try (Connection connection = dataSource.getConnection()) {
+
+            NamedPreparedStatement namedPreparedStatement = new NamedPreparedStatement(connection, userSQLQuery
+                    .getSqlQuery().toString());
+
+            for (int i = 0; i < userSQLQuery.getNumberOfPlacesToReplace(USERNAME); i++) {
+                namedPreparedStatement.setString(USERNAME, username);
+            }
+
+            for (int i = 0; i < userSQLQuery.getNumberOfPlacesToReplace(TENANT_ID); i++) {
+                namedPreparedStatement.setInt(TENANT_ID, userSQLQuery.getUserIdentifier().getTenantId());
+            }
+
+            for (int i = 0; i < userSQLQuery.getNumberOfPlacesToReplace(PSEUDONYM); i++) {
+                namedPreparedStatement.setString(PSEUDONYM, pseudonym);
+            }
+
+            namedPreparedStatement.getPreparedStatement().execute();
+
+            if (log.isDebugEnabled()) {
+                log.debug("Executed the sql query: {} for {}.", userSQLQuery.getSqlQuery().toString(), userSQLQuery
+                        .getUserIdentifier());
+            }
+        } catch (SQLException e) {
+            throw new SQLModuleException(e);
+        }
+    }
+}

--- a/components/org.wso2.carbon.privacy.forgetme.sql/src/main/java/org/wso2/carbon/privacy/forgetme/sql/sql/SQLQueryType.java
+++ b/components/org.wso2.carbon.privacy.forgetme.sql/src/main/java/org/wso2/carbon/privacy/forgetme/sql/sql/SQLQueryType.java
@@ -45,6 +45,9 @@ public enum SQLQueryType {
     SP_APP_UPDATE,
 
     //SQL update query which should be proceeded by a corresponding select query
-    SELECT_PROCEEDED_UPDATE
+    SELECT_PROCEEDED_UPDATE,
+
+    // SQL queries that has the domain appended to username and need the domain appended to pseudonym
+    DOMAIN_APPENDED_PSEUDONYM;
 
 }

--- a/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/config/ConfigConstants.java
+++ b/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/config/ConfigConstants.java
@@ -27,6 +27,7 @@ public class ConfigConstants {
     public static final String CONFIG_ELEMENT_PROCESSOR = "processor";
     public static final String CONFIG_ELEMENT_EXTENSIONS = "extensions";
     public static final String CONFIG_ELEMENT_DIRECTORIES = "directories";
+    public static final String CONFIG_ELEMENT_REPORTS = "reports";
     public static final String CONFIG_ELEMENT_TYPE = "type";
     public static final String CONFIG_ELEMENT_DIR = "dir";
     public static final String CONFIG_ELEMENT_PROPERTIES = "properties";

--- a/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/config/ReportAppenderConfig.java
+++ b/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/config/ReportAppenderConfig.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.privacy.forgetme.config;
+
+import org.wso2.carbon.privacy.forgetme.api.report.CloseableReportAppenderBuilder;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Holds configuration needed to build the report appender.
+ */
+public class ReportAppenderConfig {
+
+    private Path reportDirectoryPath;
+    private Map<String, String> properties;
+    private CloseableReportAppenderBuilder reportReader;
+
+    public ReportAppenderConfig(Path reportDirectoryPath, Map<String, String> properties, CloseableReportAppenderBuilder reportReader) {
+
+        this.reportDirectoryPath = reportDirectoryPath;
+        this.properties = properties;
+        this.reportReader = reportReader;
+    }
+
+    /**
+     * Returns the directory path configured for report generation.
+     *
+     * @return directory path
+     */
+    public Path getReportDirectoryPath() {
+
+        return reportDirectoryPath;
+    }
+
+    /**
+     * Returns properties configured
+     *
+     * @return report properties
+     */
+    public Map<String, String> getProperties() {
+
+        return properties;
+    }
+
+    /**
+     * Returns the CloseableReportAppenderBuilder instance.
+     *
+     * @return CloseableReportAppenderBuilder instance
+     */
+    public CloseableReportAppenderBuilder getReportAppenderBuilder() {
+
+        return reportReader;
+    }
+}

--- a/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/config/SystemConfig.java
+++ b/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/config/SystemConfig.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.privacy.forgetme.config;
 
+import org.wso2.carbon.privacy.forgetme.api.report.CloseableReportAppenderBuilder;
 import org.wso2.carbon.privacy.forgetme.api.runtime.InstructionReader;
 import org.wso2.carbon.privacy.forgetme.api.runtime.ProcessorConfig;
 
@@ -39,6 +40,7 @@ public class SystemConfig {
     private Map<String, ProcessorConfig> processorConfigMap = new HashMap<>();
     private List<String> processors = new ArrayList<>();
     private Path workDir;
+    private Map<String, ReportAppenderConfig> processorToReportAppenderConfigMap = new HashMap<>();
 
     /**
      * Adds an instruction reader with the given path.
@@ -91,5 +93,31 @@ public class SystemConfig {
 
     public void setWorkDir(Path workDir) {
         this.workDir = workDir;
+    }
+
+    /**
+     * Adds a report appender builder for a given processor with report appender parameters.
+     *
+     * @param processor                      processor name
+     * @param reportDirectoryPath            directory path of the report
+     * @param properties                     report properties
+     * @param closeableReportAppenderBuilder report appender builder
+     */
+    public void addReportAppenderConfig(String processor, Path reportDirectoryPath, Map<String, String> properties,
+                                        CloseableReportAppenderBuilder
+                                                closeableReportAppenderBuilder) {
+
+        processorToReportAppenderConfigMap.put(processor, new ReportAppenderConfig(reportDirectoryPath, properties,
+                closeableReportAppenderBuilder));
+    }
+
+    /**
+     * Returns the processor to report reader configuration mapping.
+     *
+     * @return a map of processor to report reader configuration
+     */
+    public Map<String, ReportAppenderConfig> getProcessorToReportAppenderConfigMap() {
+
+        return Collections.unmodifiableMap(processorToReportAppenderConfigMap);
     }
 }

--- a/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/report/PlainTextReportAppender.java
+++ b/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/report/PlainTextReportAppender.java
@@ -20,7 +20,7 @@ package org.wso2.carbon.privacy.forgetme.report;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.carbon.privacy.forgetme.api.report.ReportAppender;
+import org.wso2.carbon.privacy.forgetme.api.report.CloseableReportAppender;
 import org.wso2.carbon.privacy.forgetme.api.runtime.InstructionExecutionException;
 
 import java.io.File;
@@ -34,7 +34,7 @@ import java.nio.file.StandardOpenOption;
  * Default report generator.
  *
  */
-public class PlainTextReportAppender implements ReportAppender, AutoCloseable {
+public class PlainTextReportAppender implements CloseableReportAppender {
 
     private static final Logger logger = LoggerFactory.getLogger(PlainTextReportAppender.class);
     private File file;

--- a/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/report/PlainTextReportAppenderBuilder.java
+++ b/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/report/PlainTextReportAppenderBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.privacy.forgetme.report;
+
+import org.wso2.carbon.privacy.forgetme.api.report.CloseableReportAppender;
+import org.wso2.carbon.privacy.forgetme.api.report.CloseableReportAppenderBuilder;
+import org.wso2.carbon.privacy.forgetme.api.runtime.ModuleException;
+import org.wso2.carbon.privacy.forgetme.api.user.UserIdentifier;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+/**
+ * Report appender builder for plain text report appenders.
+ */
+public class PlainTextReportAppenderBuilder implements CloseableReportAppenderBuilder {
+
+    private static final String LOG_USER_IDENTIFIER_PROPERTY = "log-user-identifier";
+
+    @Override
+    public String getType() {
+
+        return "plain-text";
+    }
+
+    @Override
+    public CloseableReportAppender build(String processor, Path reportDirectoryPath, Map<String, String> properties,
+                                         UserIdentifier userIdentifier)
+            throws ModuleException {
+
+        Path reportFilePath = Paths.get(reportDirectoryPath.toString(), getReportFileName(processor));
+        if (properties.containsKey(LOG_USER_IDENTIFIER_PROPERTY) && Boolean.parseBoolean(properties.get(LOG_USER_IDENTIFIER_PROPERTY))) {
+            return new UserIdentifierQualifiedPlainTextReportAppender(reportFilePath.toFile(), processor,
+                    userIdentifier);
+        }
+
+        return new PlainTextReportAppender(reportFilePath.toFile(), processor);
+    }
+
+    private String getReportFileName(String processor) {
+
+        return "Report-" + processor + "-" + System.currentTimeMillis() + ".txt";
+    }
+}

--- a/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/report/UserIdentifierQualifiedPlainTextReportAppender.java
+++ b/components/org.wso2.carbon.privacy.forgetme.tool/src/main/java/org/wso2/carbon/privacy/forgetme/report/UserIdentifierQualifiedPlainTextReportAppender.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.privacy.forgetme.report;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.wso2.carbon.privacy.forgetme.api.user.UserIdentifier;
+
+import java.io.File;
+
+/**
+ * Report generator that appends user identifier details.
+ */
+public class UserIdentifierQualifiedPlainTextReportAppender extends PlainTextReportAppender {
+
+    private UserIdentifier userIdentifier;
+
+    public UserIdentifierQualifiedPlainTextReportAppender(File file, String name, UserIdentifier userIdentifier) {
+
+        super(file, name);
+        this.userIdentifier = userIdentifier;
+    }
+
+    @Override
+    public void appendSection(String format, Object... data) {
+
+        super.appendSection(getUserIdentifierQualifiedFormat(format), getExtendedData(data));
+    }
+
+    @Override
+    public void appendSectionEnd(String format, Object... data) {
+
+        super.appendSectionEnd(getUserIdentifierQualifiedFormat(format), getExtendedData(data));
+    }
+
+    private String getUserIdentifierQualifiedFormat(String format) {
+
+        return format.concat("\nUsername: %s Tenant Domain: %s User Store Domain: %s Pseudonym: %s");
+    }
+
+    private Object[] getExtendedData(Object[] data) {
+
+        int length = data.length;
+        Object[] extendedData = new Object[length + 4];
+        ArrayUtils.addAll(extendedData, data);
+        extendedData[length] = userIdentifier.getUsername();
+        extendedData[length + 1] = userIdentifier.getTenantDomain();
+        extendedData[length + 2] = userIdentifier.getUserStoreDomain();
+        extendedData[length + 3] = userIdentifier.getPseudonym();
+
+        return extendedData;
+    }
+}

--- a/components/org.wso2.carbon.privacy.forgetme.tool/src/main/resources/META-INF/services/org.wso2.carbon.privacy.forgetme.api.report.CloseableReportAppenderBuilder
+++ b/components/org.wso2.carbon.privacy.forgetme.tool/src/main/resources/META-INF/services/org.wso2.carbon.privacy.forgetme.api.report.CloseableReportAppenderBuilder
@@ -1,0 +1,1 @@
+org.wso2.carbon.privacy.forgetme.report.PlainTextReportAppenderBuilder


### PR DESCRIPTION
## Purpose
Resolves wso2/product-is#4116
Resolves wso2/identity-anonymization-tool#90

## Goals
The existing extension to support renaming username incurs following problems which are fixed in this PR.
- Does not properly load the secondary user store file for the given user store domain
- In tables where user store domain is appended to the username, when updating the pseudonym the user store domain is not appended to the pseudonym. Thus, the new username which is provided as the pseudonym is not updated with the appended user store domain.
- No indication on the identifier that has been changed in tool generated logs

## Approach
 - Added a SQLExecutionModule to append the user store domain to the pseudonym
- Deprecated redundant API
- Added support to plug report appenders and configure them accordingly. A sample configuration that goes to config.json is below.
`"reports": [
    {
    "dir": ".",
    "type": "plain-text",
    "processor": "user-store",
    "properties": [
        {
          "log-user-identifier": "true"
        }
      ]
    }
   ]`
There are two plaintext appenders supported OOTB.
One would not log the user identifier in the report and the other would log.
Based on the log-user-identifier property appropriate appender is initiated.
With the above config the path to store reports can be configured relative to the directory where the configuration file resides.

## User stories
- A user wants to change the username which is the primary identifier of the user.
- A DevOp wants to change the path of tool execution reports generated

## Documentation
https://github.com/wso2/product-is/issues/4116#issuecomment-447089004
https://github.com/wso2/identity-anonymization-tool/issues/90#issuecomment-445558178

## Related PRs

## Migrations (if applicable)
NA