### PR TITLE
log4j2 Migration in Forgetme Tool

### DIFF
--- a/components/org.wso2.carbon.privacy.forgetme.analytics.streams/pom.xml
+++ b/components/org.wso2.carbon.privacy.forgetme.analytics.streams/pom.xml
@@ -36,16 +36,6 @@
             <artifactId>commons-text</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.privacy</groupId>
             <artifactId>org.wso2.carbon.privacy.forgetme.api</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.privacy.forgetme.logs/pom.xml
+++ b/components/org.wso2.carbon.privacy.forgetme.logs/pom.xml
@@ -19,12 +19,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
         </dependency>
-
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.wso2.carbon.privacy</groupId>
             <artifactId>org.wso2.carbon.privacy.forgetme.api</artifactId>

--- a/components/org.wso2.carbon.privacy.forgetme.logs/pom.xml
+++ b/components/org.wso2.carbon.privacy.forgetme.logs/pom.xml
@@ -19,14 +19,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.wso2.carbon.privacy</groupId>
             <artifactId>org.wso2.carbon.privacy.forgetme.api</artifactId>
@@ -41,6 +39,10 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
         </dependency>
     </dependencies>
 

--- a/components/org.wso2.carbon.privacy.forgetme.logs/src/main/java/org/wso2/carbon/privacy/forgetme/logs/instructions/LogFileInstruction.java
+++ b/components/org.wso2.carbon.privacy.forgetme.logs/src/main/java/org/wso2/carbon/privacy/forgetme/logs/instructions/LogFileInstruction.java
@@ -18,8 +18,8 @@
 
 package org.wso2.carbon.privacy.forgetme.logs.instructions;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.privacy.forgetme.api.report.ReportAppender;
 import org.wso2.carbon.privacy.forgetme.api.runtime.Environment;
 import org.wso2.carbon.privacy.forgetme.api.runtime.ForgetMeInstruction;
@@ -40,7 +40,7 @@ import java.util.List;
  */
 public class LogFileInstruction implements ForgetMeInstruction {
 
-    private static final Logger log = LoggerFactory.getLogger(LogFileInstruction.class);
+    private static final Log log = LogFactory.getLog(LogFileInstruction.class);
 
     private List<Patterns.Pattern> patterns;
     private File logFile;
@@ -61,7 +61,7 @@ public class LogFileInstruction implements ForgetMeInstruction {
         LogFileProcessor logFileProcessor = new LogFileProcessor();
 
         if (log.isDebugEnabled()) {
-            log.debug("File {} is being processed.", logFile.getName());
+            log.debug("File {} is being processed." + logFile.getName());
         }
 
         logFileProcessor.processFiles(userIdentifier, reportAppender, patterns, logFiles);

--- a/components/org.wso2.carbon.privacy.forgetme.logs/src/main/java/org/wso2/carbon/privacy/forgetme/logs/instructions/LogFileInstructionReader.java
+++ b/components/org.wso2.carbon.privacy.forgetme.logs/src/main/java/org/wso2/carbon/privacy/forgetme/logs/instructions/LogFileInstructionReader.java
@@ -18,8 +18,8 @@
 
 package org.wso2.carbon.privacy.forgetme.logs.instructions;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.privacy.forgetme.api.runtime.Environment;
 import org.wso2.carbon.privacy.forgetme.api.runtime.ForgetMeInstruction;
 import org.wso2.carbon.privacy.forgetme.api.runtime.ModuleException;
@@ -46,7 +46,7 @@ import javax.xml.bind.Unmarshaller;
  */
 public class LogFileInstructionReader implements InstructionReader {
 
-    private static final Logger log = LoggerFactory.getLogger(LogFileInstructionReader.class);
+    private static final Log log = LogFactory.getLog(LogFileInstructionReader.class);
 
     private static final String NAME = "log-file";
     private static final String LOG_FILE_PATH_PROPERTY = "log-file-path";

--- a/components/org.wso2.carbon.privacy.forgetme.logs/src/main/java/org/wso2/carbon/privacy/forgetme/logs/processor/LogFileProcessor.java
+++ b/components/org.wso2.carbon.privacy.forgetme.logs/src/main/java/org/wso2/carbon/privacy/forgetme/logs/processor/LogFileProcessor.java
@@ -20,8 +20,8 @@ package org.wso2.carbon.privacy.forgetme.logs.processor;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StrSubstitutor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.privacy.forgetme.api.report.ReportAppender;
 import org.wso2.carbon.privacy.forgetme.api.user.UserIdentifier;
 import org.wso2.carbon.privacy.forgetme.logs.LogProcessorConstants;
@@ -51,7 +51,7 @@ import java.util.regex.Pattern;
  */
 public class LogFileProcessor {
 
-    private static Logger log = LoggerFactory.getLogger(LogFileProcessor.class);
+    private static Log log = LogFactory.getLog(LogFileProcessor.class);
 
     private final static Charset ENCODING = StandardCharsets.UTF_8;
     private static final String TEMP_FILE_PREFIX = "anon-";
@@ -64,7 +64,7 @@ public class LogFileProcessor {
         for (File file : fileList) {
             reportAppender.appendSection("Starting File %s", file.getAbsolutePath());
             if (log.isDebugEnabled()) {
-                log.debug("Reading log file {}.", file.getName());
+                log.debug("Reading log file {}." + file.getName());
             }
             try (BufferedReader reader = Files.newBufferedReader(file.toPath(), ENCODING);
                     LineNumberReader lineReader = new LineNumberReader(reader);
@@ -92,12 +92,12 @@ public class LogFileProcessor {
                                         .getPseudonym());
                                 reportAppender.append("Replaced, %d, %b", lineReader.getLineNumber(), true);
                                 if (log.isDebugEnabled()) {
-                                    log.debug("Replaced {}", lineReader.getLineNumber());
+                                    log.debug("Replaced {}" + lineReader.getLineNumber());
                                 }
                             } else {
                                 reportAppender.append("Not Replaced, %d, %b", lineReader.getLineNumber(), true);
                                 if (log.isDebugEnabled()) {
-                                    log.debug("Not replaced {}", lineReader.getLineNumber());
+                                    log.debug("Not replaced {}" + lineReader.getLineNumber());
                                 }
                             }
                         }
@@ -114,7 +114,7 @@ public class LogFileProcessor {
             } catch (Exception ex) {
                 throw new LogProcessorException("Error occurred while processing log file.", ex);
             }
-            log.info("Completed scanning log file: {}", file);
+            log.info("Completed scanning log file: {}" + file);
             reportAppender.appendSectionEnd("Completed " + file);
         }
     }
@@ -124,7 +124,7 @@ public class LogFileProcessor {
         List<MatchAndReplace> result = new ArrayList<>(patternList.size());
         for (Patterns.Pattern pattern : patternList) {
             if (log.isDebugEnabled()) {
-                log.debug("Compiling pattern {}.", pattern.getKey());
+                log.debug("Compiling pattern {}." + pattern.getKey());
             }
             String formattedDetectPattern = StrSubstitutor.replace(pattern.getDetectPattern(), templatePatternData)
                     .trim();

--- a/components/org.wso2.carbon.privacy.forgetme.sql/pom.xml
+++ b/components/org.wso2.carbon.privacy.forgetme.sql/pom.xml
@@ -41,14 +41,6 @@
             <artifactId>org.wso2.carbon.datasource.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.privacy.forgetme.tool/pom.xml
+++ b/components/org.wso2.carbon.privacy.forgetme.tool/pom.xml
@@ -183,14 +183,6 @@
             <artifactId>h2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.privacy.forgetme.tool/pom.xml
+++ b/components/org.wso2.carbon.privacy.forgetme.tool/pom.xml
@@ -183,6 +183,14 @@
             <artifactId>h2</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.privacy.forgetme.userstore/pom.xml
+++ b/components/org.wso2.carbon.privacy.forgetme.userstore/pom.xml
@@ -45,14 +45,6 @@
             <artifactId>org.wso2.carbon.user.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -147,14 +147,19 @@
             </dependency>
 
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${org.slf4j.version}</version>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${commons.logging.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>${org.slf4j.version}</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-jcl</artifactId>
+                <version>${log4j.jcl.version}</version>
             </dependency>
 
             <dependency>
@@ -259,7 +264,7 @@
         <org.apache.commons.version>1.6</org.apache.commons.version>
         <com.googlecode.json.simple.version>1.1.1</com.googlecode.json.simple.version>
 
-        <org.slf4j.version>1.7.26</org.slf4j.version>
+        <commons.logging.version>1.2</commons.logging.version>
 
         <maven.surefire.plugin.version>2.22.1</maven.surefire.plugin.version>
         <maven.resource.plugin.version>3.1.0</maven.resource.plugin.version>
@@ -272,6 +277,10 @@
 
         <org.junit.version>3.8.1</org.junit.version>
         <org.testng.version>6.14.3</org.testng.version>
+
+        <!-- Log4j -->
+        <log4j.core.version>2.14.1</log4j.core.version>
+        <log4j.jcl.version>2.14.1</log4j.jcl.version>
 
         <!-- Carbon component versions -->
         <carbon.kernel.version>4.6.1-alpha</carbon.kernel.version>


### PR DESCRIPTION
Log4j1.x has security vulnerability concerns. Hence log4j1.x is migrated to log4j2 with commons-logging and relevant java classes are modified accordingly.