### PR TITLE
Dependancy version update of commons-io and update carbon.datasources version

### DIFF
--- a/components/org.wso2.carbon.privacy.forgetme.sql/src/main/java/org/wso2/carbon/privacy/forgetme/sql/instructions/DatasourceProcessorConfigReader.java
+++ b/components/org.wso2.carbon.privacy.forgetme.sql/src/main/java/org/wso2/carbon/privacy/forgetme/sql/instructions/DatasourceProcessorConfigReader.java
@@ -18,6 +18,9 @@
 
 package org.wso2.carbon.privacy.forgetme.sql.instructions;
 
+import org.wso2.carbon.config.ConfigProviderFactory;
+import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.config.provider.ConfigProvider;
 import org.wso2.carbon.datasource.core.DataSourceManager;
 import org.wso2.carbon.datasource.core.exception.DataSourceException;
 import org.wso2.carbon.privacy.forgetme.api.runtime.ProcessorConfigReader;
@@ -42,8 +45,9 @@ public class DatasourceProcessorConfigReader implements ProcessorConfigReader<Da
         DataSourceManager dataSourceManager = DataSourceManager.getInstance();
 
         try {
-            dataSourceManager.initDataSources(path.toAbsolutePath().toString());
-        } catch (DataSourceException e) {
+            ConfigProvider configProvider = ConfigProviderFactory.getConfigProvider(path);
+            dataSourceManager.initDataSources(configProvider);
+        } catch (DataSourceException | ConfigurationException e) {
             throw new SQLModuleException("Error occurred while initializing the data source.", e);
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
         <java.source.version>1.8</java.source.version>
         <java.target.version>1.8</java.target.version>
 
-        <carbon.datasource.version>1.0.4</carbon.datasource.version>
+        <carbon.datasource.version>1.1.10</carbon.datasource.version>
 
         <com.h2database.version>1.4.199</com.h2database.version>
 
@@ -281,7 +281,7 @@
         <jaxb.api.version>2.3.1</jaxb.api.version>
         <jaxb.impl.version>2.3.2</jaxb.impl.version>
         <gson.version>2.8.5</gson.version>
-        <commons-io.version>2.6</commons-io.version>
+        <commons-io.version>2.7</commons-io.version>
 
         <cxf-bundle.version>3.2.8</cxf-bundle.version>
         <jackson.version>1.9.11</jackson.version>


### PR DESCRIPTION
Related Issues: wso2/product-is#12485
## Purpose
> Bump commons-io version to 2.7
> Bump carbon.datasources version to 1.1.10
> Bump kernel version to 4.7.0-m4

`org.wso2.carbon.privacy.forgetme.tool` is depend on carbon.datasources. Hence needed to update commons-io version in carbon.datasources and bump the version here in order to bump commons-io version to 2.7.

This PR is depend on https://github.com/wso2/carbon-datasources/pull/56