### PR TITLE
Add javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,26 @@
                     <target>${java.target.version}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <source>1.8</source>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <!--This parameter disables doclint-->
+                            <doclint>none</doclint>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Related Issues: wso2/product-is#12229
Related PRs: #139
## Purpose
> Jenkins release build failed due to `javadoc` issues. To fix that we need to add javadoc plugin with `doclint:none`.