### PR TITLE
Add remote audit server log config log entry

### DIFF
--- a/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/carbon-4.4.x/log-config/patterns.xml
+++ b/components/org.wso2.carbon.privacy.forgetme.conf/src/main/resources/carbon-4.4.x/log-config/patterns.xml
@@ -58,4 +58,9 @@
         <replacePattern>${username}@${tenantDomain}</replacePattern>
     </pattern>
 
+    <pattern key="pattern8">
+        <detectPattern>(TID: )\[${tenantId}\](.)*(Remote audit server logging configuration updated successfully with url:)(.*)(by user:)(\s)*${username}(\s)*(for appender:)</detectPattern>
+        <replacePattern>${username}</replacePattern>
+    </pattern>
+
 </patterns>


### PR DESCRIPTION
## Purpose
This PR adds the remote audit server logging configuration log entry to `patterns.xml` file.

Related to https://github.com/wso2/api-manager/issues/1565

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes